### PR TITLE
Document Dart dot shorthand usage

### DIFF
--- a/skills/dart-language-syntax/SKILL.md
+++ b/skills/dart-language-syntax/SKILL.md
@@ -114,7 +114,39 @@ Implements idiomatic Dart code leveraging advanced syntax, including pattern mat
    }
    ```
 
-7. **Validate and Fix**
+7. **Dot shorthands**
+   Use dot shorthand syntax (leading `.`) to omit the type when the compiler can infer it from context (requires Dart 3.10+).
+   * Context type is what the surrounding code expects (e.g. the variable being assigned, or the left-hand side of `==`).
+   * Prefer `.member` for enum values, static methods/fields, and constructors when the context type is clear (assignments, switch cases, parameter types).
+   * Use `.new()` for unnamed constructors where the type is already declared.
+   * In equality checks, use dot shorthand only on the **right-hand side** of `==` or `!=`; expression statements cannot start with `.`.
+   ```dart
+   // Enum values
+   enum Status { none, running, stopped, paused }
+   Status currentStatus = .running;
+
+   // Static members
+   int port = .parse('8080');
+   BigInt zero = .zero;
+
+   // Named and unnamed constructors
+   Point origin = .origin();
+   final ScrollController _scrollController = .new();
+   List<int> intList = .filled(5, 0);
+
+   // Switch over enum
+   return switch (level) {
+     .debug => 'gray',
+     .info => 'blue',
+     .error => 'red',
+     _ => 'unknown',
+   };
+
+   // Equality on right-hand side only
+   if (myColor == .green) { ... }
+   ```
+
+8. **Validate and Fix**
    After generating Dart code, verify that:
    * No null dereference errors are possible.
    * Records are used instead of custom classes for simple data tuples.


### PR DESCRIPTION
Add a new "Dot shorthands" section describing the leading `.` syntax (Dart 3.10+) with guidance on context typing, using `.member` for enums and static members, `.new()` for unnamed constructors, and the restriction that dot shorthand appears on the right-hand side of `==`/`!=`. Includes examples for enums, static members, constructors, lists, and switch cases. Renumber the subsequent "Validate and Fix" section to 8.

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
