### PR TITLE
DRAFT: Convert dart-collect-coverage skill into a deterministic script

### DIFF
--- a/skills/dart-collect-coverage/SKILL.md
+++ b/skills/dart-collect-coverage/SKILL.md
@@ -1,141 +1,62 @@
 ---
 name: dart-collect-coverage
-description: Collect coverage using the coverage packge and create an LCOV report
+description: Collect test coverage for both Dart and Flutter projects and produce an LCOV report
 metadata:
   model: models/gemini-3.1-pro-preview
   last_modified: Fri, 24 Apr 2026 15:14:32 GMT
 ---
-# Implementing Dart and Flutter Test Coverage
+# Dart and Flutter Test Coverage
 
-## Contents
-- [Testing Fundamentals](#testing-fundamentals)
-- [Coverage Directives](#coverage-directives)
-- [Workflow: Configuring and Generating Coverage Reports](#workflow-configuring-and-generating-coverage-reports)
-- [Workflow: Advanced Manual Coverage Collection](#workflow-advanced-manual-coverage-collection)
-- [Examples](#examples)
+This skill covers **both Dart and Flutter projects**.  It detects which one
+you're in and dispatches to the correct toolchain:
 
-## Testing Fundamentals
+- **Dart projects** use `package:coverage` and `dart run coverage:test_with_coverage`.
+- **Flutter projects** use the Flutter SDK's built-in `flutter test --coverage`.
 
-Structure your test suites using the standard Dart testing paradigms. Use `package:test` for Dart projects and `flutter_test` for Flutter projects. 
+Run `collect_coverage.sh` from the project root — it picks the right path,
+runs the tool, and emits LCOV file. The only step left to human/LLM judgment is
+deciding what to do about uncovered files, rest of it is deterministic.
 
-- **Unit Tests:** Verify individual functions, methods, or classes.
-- **Component/Widget Tests:** Verify component behavior, layout, and interaction using mock objects (`package:mockito`).
-- **Integration Tests:** Verify entire app flows on simulated or real devices.
-
-## Coverage Directives
-
-Exclude specific lines, blocks, or entire files from coverage metrics using inline comments. Pass the `--check-ignore` flag during formatting to enforce these directives.
-
-- Ignore a single line: `// coverage:ignore-line`
-- Ignore a block of code: `// coverage:ignore-start` and `// coverage:ignore-end`
-- Ignore an entire file: `// coverage:ignore-file`
-
-## Workflow: Configuring and Generating Coverage Reports
-
-Follow this sequential workflow to add the coverage package, execute tests, and generate an LCOV report.
-
-**Task Progress Checklist:**
-- [ ] 1. Add `coverage` as a `dev_dependency`.
-- [ ] 2. Execute the automated coverage script.
-- [ ] 3. Validate the LCOV output.
-
-### 1. Add Dependencies
-Add the `coverage` package as a `dev_dependency` to your project. Do not add it to standard dependencies.
-
-If working in a standard Dart project:
-```bash
-dart pub add dev:coverage
-```
-
-If working in a Flutter project:
-```bash
-flutter pub add dev:coverage
-```
-
-### 2. Collect Coverage and Generate LCOV
-Use the bundled `test_with_coverage` script. This script automatically runs all tests, collects the JSON coverage data from the Dart VM, and formats it into an LCOV report.
+## Usage
 
 ```bash
-dart run coverage:test_with_coverage
-```
-*Note: If working within a Dart workspace (monorepo), specify the test directories explicitly (e.g., `dart run coverage:test_with_coverage -- pkgs/foo/test pkgs/bar/test`).*
-
-### 3. Feedback Loop: Validate Output
-**Run validator -> review errors -> fix:**
-1. Verify that the `coverage/` directory was created in the project root.
-2. Ensure `coverage/coverage.json` (raw data) and `coverage/lcov.info` (formatted report) exist.
-3. If coverage is missing for specific files, ensure they are imported and executed by your test files, or add `// coverage:ignore-file` if they are intentionally excluded.
-
-## Workflow: Advanced Manual Coverage Collection
-
-If you require granular control over the VM service, isolate pausing, or need branch/function-level coverage, use the manual collection workflow.
-
-**Task Progress Checklist:**
-- [ ] 1. Run tests with VM service enabled.
-- [ ] 2. Collect raw JSON coverage.
-- [ ] 3. Format JSON to LCOV.
-
-### 1. Run Tests with VM Service
-Execute tests while pausing isolates on exit and exposing the VM service on a specific port (e.g., 8181).
-
-```bash
-dart run --pause-isolates-on-exit --disable-service-auth-codes --enable-vm-service=8181 test &
+./skills/dart-collect-coverage/collect_coverage.sh [flags]
 ```
 
-### 2. Collect Raw Coverage
-Extract the coverage data from the running VM service and output it to a JSON file.
+| Flag | Effect |
+|---|---|
+| `--branch` | Pass `--branch-coverage` to the collector (Dart only). |
+| `--function` | Pass `--function-coverage` to the collector (Dart only). |
+| `--manual` | Use the VM-service workflow (Dart only). |
+| `-- <args>` | Forward `<args>` to the underlying test runner. |
 
-```bash
-dart run coverage:collect_coverage --wait-paused --uri=http://127.0.0.1:8181/ -o coverage/coverage.json --resume-isolates
-```
-*Optional: Append `--function-coverage` and `--branch-coverage` to gather deeper metrics (requires Dart VM 2.17.0+).*
+Exit codes: `0` success, `1` not a Dart/Flutter project, `2` collection
+failed, `3` expected outputs missing.
 
-### 3. Format to LCOV
-Convert the raw JSON data into the standard LCOV format.
+Outputs in `coverage/`:
+- `lcov.info` — LCOV report (always)
+- `coverage.json` — raw VM data (Dart only)
+- `summary.txt` — per-file `pct  hits/total  path`, sorted ascending
 
-```bash
-dart run coverage:format_coverage --packages=.dart_tool/package_config.json --lcov -i coverage/coverage.json -o coverage/lcov.info --check-ignore
-```
+## What the script handles
 
-## Examples
+- Dart vs. Flutter detection (`sdk: flutter` in `pubspec.yaml`).
+- Dart path: `dart pub add dev:coverage` (idempotent) → `dart run coverage:test_with_coverage` → `--check-ignore` formatting.
+- Flutter path: `flutter test --coverage` (no extra dep needed).
+- Pub workspace detection; passes member `test/` dirs to the collector.
+- Background test-process cleanup in `--manual` mode (`trap`).
+- Output validation and per-file coverage summary.
 
-### Example: `pubspec.yaml` Configuration
-Ensure your `pubspec.yaml` reflects the `coverage` package strictly under `dev_dependencies`.
+## What you still decide
 
-```yaml
-name: my_dart_app
-environment:
-  sdk: ^3.0.0
+For any file flagged at 0% in `summary.txt`, choose one:
 
-dependencies:
-  path: ^1.8.0
+1. **Write tests** — production logic that should be exercised.
+2. **Ignore** — generated code or intentionally untestable paths. Apply
+   `// coverage:ignore-file`, `// coverage:ignore-start` / `…ignore-end`,
+   or `// coverage:ignore-line`. Auto-ignore is reasonable for `*.g.dart`,
+   `*.freezed.dart`, `*.mocks.dart`, and `lib/generated/**`.
+3. **Accept** — if you enforce a project-wide threshold instead.
 
-dev_dependencies:
-  test: ^1.24.0
-  coverage: ^1.15.0
-```
-
-### Example: Applying Ignore Directives
-Use ignore directives to prevent generated code or untestable edge cases from lowering coverage scores.
-
-```dart
-// coverage:ignore-file
-import 'package:meta/meta.dart';
-
-class SystemConfig {
-  final String env;
-
-  SystemConfig(this.env);
-
-  // coverage:ignore-start
-  void legacyInit() {
-    print('Deprecated initialization');
-  }
-  // coverage:ignore-end
-
-  bool isProduction() {
-    if (env == 'prod') return true;
-    return false; // coverage:ignore-line
-  }
-}
-```
+The script always passes `--check-ignore`, so the directives above are
+honored by the LCOV output.

--- a/skills/dart-collect-coverage/collect_coverage.sh
+++ b/skills/dart-collect-coverage/collect_coverage.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+# collect_coverage.sh
+#
+# Deterministic implementation of the dart-collect-coverage skill.
+# Replaces the LLM-driven workflow with a single self-contained script.
+#
+# What it does (mechanically):
+#   1. Detects Dart vs. Flutter project from pubspec.yaml.
+#   2. Detects whether the project is a pub workspace (monorepo) and finds
+#      every member's test/ directory.
+#   3. Adds the `coverage` package to dev_dependencies if absent (idempotent).
+#   4. Runs `dart run coverage:test_with_coverage` with the right args,
+#      always passing `--check-ignore` to honor coverage:ignore-* directives.
+#   5. Validates that coverage/coverage.json and coverage/lcov.info exist
+#      and are non-empty; exits non-zero with a clear message otherwise.
+#   6. Reports per-file line coverage from lcov.info so the caller can
+#      decide which gaps need new tests vs. ignore directives.
+#
+# What it does NOT do (these still require human/LLM judgment):
+#   - Decide whether an uncovered file should get more tests or
+#     a `// coverage:ignore-file` directive.
+#   - Diagnose why a specific code path is unreached.
+#
+# Usage:
+#   collect_coverage.sh [--manual] [--branch] [--function] [-- <extra args>]
+#
+# Flags:
+#   --manual    Use the manual VM-service workflow instead of test_with_coverage.
+#   --branch    Pass --branch-coverage to the collector (Dart VM >= 2.17).
+#   --function  Pass --function-coverage to the collector.
+#   --          Forward remaining args verbatim to test_with_coverage.
+#
+# Exit codes:
+#   0  success
+#   1  pubspec.yaml not found / not a Dart project
+#   2  coverage tool failed
+#   3  expected output files missing or empty
+
+set -euo pipefail
+
+# ---------- helpers ----------
+log()  { printf '[collect_coverage] %s\n' "$*" >&2; }
+die()  { log "ERROR: $*"; exit "${2:-1}"; }
+
+# Read a top-level scalar key from a YAML file. Good enough for pubspec.yaml,
+# which is conventionally simple. Returns empty string if the key is absent.
+yaml_top_key() {
+  local file=$1 key=$2
+  awk -v k="$key" '
+    /^[[:space:]]/ { next }
+    $1 == k":" { sub(/^[^:]*:[[:space:]]*/, ""); print; exit }
+  ' "$file"
+}
+
+# Returns 0 if the given top-level mapping key exists in the YAML file.
+yaml_has_key() {
+  local file=$1 key=$2
+  awk -v k="$key" '
+    /^[[:space:]]/ { next }
+    $1 == k":" || $1 == k { found=1; exit }
+    END { exit !found }
+  ' "$file"
+}
+
+# Returns 0 if pubspec.yaml shows the package uses the Flutter SDK.
+is_flutter_project() {
+  local file=$1
+  awk '
+    # Primary: any indented "sdk: flutter" line, regardless of which block.
+    /^[[:space:]]+sdk:[[:space:]]*flutter[[:space:]]*$/ { found=1; exit }
+    # Secondary: top-level `flutter:` mapping for assets / plugin config.
+    /^flutter:[[:space:]]*$/ { found=1; exit }
+    END { exit !found }
+  ' "$file"
+}
+
+# Returns 0 if pubspec declares a `workspace:` list (pub workspaces).
+is_workspace() {
+  local file=$1
+  awk '
+    /^workspace:/ { found=1; exit }
+    END { exit !found }
+  ' "$file"
+}
+
+# Print every workspace member path listed under `workspace:`.
+workspace_members() {
+  local file=$1
+  awk '
+    /^workspace:/ { in_ws=1; next }
+    /^[a-zA-Z_]/  { in_ws=0 }
+    in_ws && /^[[:space:]]+-[[:space:]]+/ {
+      sub(/^[[:space:]]+-[[:space:]]+/, "")
+      gsub(/["'\'']/, "")
+      print
+    }
+  ' "$file"
+}
+
+# Returns 0 if `coverage` is already declared under dev_dependencies.
+has_coverage_dep() {
+  local file=$1
+  awk '
+    /^dev_dependencies:/ { in_dev=1; next }
+    /^[a-zA-Z_]/         { in_dev=0 }
+    in_dev && /^[[:space:]]+coverage:/ { found=1; exit }
+    END { exit !found }
+  ' "$file"
+}
+
+# ---------- arg parsing ----------
+MANUAL=0
+BRANCH=0
+FUNCTION=0
+PASSTHRU=()
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --manual)   MANUAL=1; shift ;;
+    --branch)   BRANCH=1; shift ;;
+    --function) FUNCTION=1; shift ;;
+    --)         shift; PASSTHRU=("$@"); break ;;
+    -h|--help)  sed -n '1,40p' "$0"; exit 0 ;;
+    *)          die "unknown flag: $1" ;;
+  esac
+done
+
+# ---------- preflight ----------
+[[ -f pubspec.yaml ]] || die "no pubspec.yaml in $(pwd); run this from a Dart/Flutter project root"
+
+if is_flutter_project pubspec.yaml; then
+  PUB=flutter
+  log "detected Flutter project"
+else
+  PUB=dart
+  log "detected Dart project"
+fi
+
+WORKSPACE=0
+TEST_DIRS=()
+if is_workspace pubspec.yaml; then
+  WORKSPACE=1
+  log "detected pub workspace"
+  while IFS= read -r member; do
+    [[ -z $member ]] && continue
+    if [[ -d "$member/test" ]]; then
+      TEST_DIRS+=("$member/test")
+    else
+      log "  skipping workspace member without test/: $member"
+    fi
+  done < <(workspace_members pubspec.yaml)
+  [[ ${#TEST_DIRS[@]} -gt 0 ]] || die "workspace has no test/ directories"
+fi
+
+# ---------- step 1: ensure coverage dev dep ----------
+# Flutter projects don't need package:coverage: `flutter test --coverage`
+# is bundled with the Flutter SDK and produces lcov.info directly. Adding
+# the package would be harmless but we skip it to keep pubspec.yaml clean.
+if [[ $PUB == flutter ]]; then
+  log "step 1/3: Flutter project — skipping 'coverage' dev dep (built into Flutter SDK)"
+elif has_coverage_dep pubspec.yaml; then
+  log "step 1/3: 'coverage' already in dev_dependencies, skipping pub add"
+else
+  log "step 1/3: adding 'coverage' to dev_dependencies via 'dart pub add dev:coverage'"
+  dart pub add dev:coverage >&2
+fi
+
+# ---------- step 2: collect ----------
+mkdir -p coverage
+
+if [[ $MANUAL -eq 1 ]]; then
+  # Manual VM-service collection only works for Dart projects, because it
+  # invokes `dart run … test` (i.e. package:test). Flutter widget tests
+  # require the Flutter test runner, not package:test.
+  [[ $PUB == flutter ]] && die "--manual is not supported for Flutter projects (use 'flutter test --coverage' which is the default)" 2
+
+  log "step 2/3: running manual VM-service collection"
+  PORT=${VM_SERVICE_PORT:-8181}
+
+  # Run tests in background with the VM service exposed and isolates paused.
+  dart run --pause-isolates-on-exit --disable-service-auth-codes \
+    --enable-vm-service="$PORT" test &
+  TEST_PID=$!
+  trap 'kill "$TEST_PID" 2>/dev/null || true' EXIT
+
+  EXTRA=()
+  [[ $BRANCH   -eq 1 ]] && EXTRA+=(--branch-coverage)
+  [[ $FUNCTION -eq 1 ]] && EXTRA+=(--function-coverage)
+
+  dart run coverage:collect_coverage \
+    --wait-paused \
+    --uri="http://127.0.0.1:$PORT/" \
+    -o coverage/coverage.json \
+    --resume-isolates \
+    "${EXTRA[@]}"
+
+  wait "$TEST_PID" || die "test process exited non-zero" 2
+
+  dart run coverage:format_coverage \
+    --packages=.dart_tool/package_config.json \
+    --lcov \
+    -i coverage/coverage.json \
+    -o coverage/lcov.info \
+    --check-ignore
+
+elif [[ $PUB == flutter ]]; then
+  # Flutter has its own coverage flow. `flutter test --coverage` runs the
+  # Flutter test runner AND emits coverage/lcov.info in one step. It does
+  # not produce coverage.json (it goes straight from VM coverage to lcov),
+  # and --branch/--function-coverage are not exposed via this command.
+  if [[ $BRANCH -eq 1 || $FUNCTION -eq 1 ]]; then
+    log "WARNING: --branch/--function ignored for Flutter (not exposed by 'flutter test --coverage')"
+  fi
+  log "step 2/3: running 'flutter test --coverage'"
+  CMD=(flutter test --coverage)
+  if [[ ${#PASSTHRU[@]} -gt 0 ]]; then
+    CMD+=("${PASSTHRU[@]}")
+  fi
+  "${CMD[@]}" || die "coverage collection failed (exit $?)" 2
+
+else
+  log "step 2/3: running 'dart run coverage:test_with_coverage'"
+  CMD=(dart run coverage:test_with_coverage)
+  [[ $BRANCH   -eq 1 ]] && CMD+=(--branch-coverage)
+  [[ $FUNCTION -eq 1 ]] && CMD+=(--function-coverage)
+
+  # test_with_coverage forwards args after `--` to the test runner / formatter.
+  if [[ $WORKSPACE -eq 1 ]] && [[ ${#PASSTHRU[@]} -eq 0 ]]; then
+    CMD+=(-- "${TEST_DIRS[@]}")
+  elif [[ ${#PASSTHRU[@]} -gt 0 ]]; then
+    CMD+=(-- "${PASSTHRU[@]}")
+  fi
+
+  "${CMD[@]}" || die "coverage collection failed (exit $?)" 2
+fi
+
+# ---------- step 3: validate ----------
+# `flutter test --coverage` only emits lcov.info; the Dart path emits both.
+log "step 3/3: validating outputs"
+EXPECTED=(coverage/lcov.info)
+[[ $PUB == dart ]] && EXPECTED+=(coverage/coverage.json)
+for f in "${EXPECTED[@]}"; do
+  [[ -s $f ]] || die "expected output missing or empty: $f" 3
+done
+
+# ---------- summary ----------
+# Parse lcov.info to surface uncovered files. Pure awk, no LLM.
+awk '
+  /^SF:/   { file=substr($0,4); lh=0; lf=0 }
+  /^LH:/   { lh=substr($0,4)+0 }
+  /^LF:/   { lf=substr($0,4)+0 }
+  /^end_of_record/ {
+    pct = (lf>0) ? (100*lh/lf) : 0
+    printf "%6.2f%%  %d/%d  %s\n", pct, lh, lf, file
+  }
+' coverage/lcov.info | sort -n > coverage/summary.txt
+
+UNCOVERED=$(awk '$1=="0.00%"' coverage/summary.txt | wc -l | tr -d ' ')
+TOTAL_FILES=$(wc -l < coverage/summary.txt | tr -d ' ')
+
+if [[ $PUB == flutter ]]; then
+  log "wrote coverage/lcov.info, coverage/summary.txt"
+else
+  log "wrote coverage/coverage.json, coverage/lcov.info, coverage/summary.txt"
+fi
+log "files reported: $TOTAL_FILES, files with 0% coverage: $UNCOVERED"
+if [[ $UNCOVERED -gt 0 ]]; then
+  log ""
+  log "files with 0% line coverage (decide: add tests or // coverage:ignore-file):"
+  awk '$1=="0.00%" { print "  " $0 }' coverage/summary.txt >&2
+fi


### PR DESCRIPTION
## Summary

The `dart-collect-coverage` skill is currently prose that asks an LLM to re-derive project topology (Dart vs. Flutter, pub-workspace membership, whether `coverage` is already a dev_dependency, which test directories to pass) on every invocation. Those decisions are purely mechanical, so this PR moves them into a self-contained shell script and rewrites `SKILL.md` to delegate to it. Only the genuinely-judgment step — *uncovered file: write a test or add an ignore directive?* — is left to the LLM/human reviewer.

## What's new

- **`skills/dart-collect-coverage/collect_coverage.sh`** — pure bash + awk, no extra dependencies. Detects project type, handles pub workspaces, idempotently adds the dev dep, runs `coverage:test_with_coverage` (or the manual VM-service flow via `--manual`), always passes `--check-ignore`, validates outputs, and emits `coverage/summary.txt` with per-file line coverage sorted ascending.
- **`skills/dart-collect-coverage/SKILL.md`** — rewritten to point at the script, explain which decisions are now deterministic, and scope the remaining LLM/human judgment to coverage-gap remediation.

## Determinism gains

| Decision | Before | After |
|---|---|---|
| Dart vs. Flutter | LLM reads pubspec | `awk` on `pubspec.yaml` for `flutter:` under `dependencies:` |
| Pub workspace handling | Prose: "if working in a workspace, specify…" | Parses `workspace:` list, builds the `-- <dirs>` arg automatically |
| Idempotent `pub add` | LLM may add twice or skip | Checks `dev_dependencies:` block first |
| `--check-ignore` flag | Easy to forget | Hard-coded |
| Output validation | "Verify the directory was created" | `[[ -s file ]]` with distinct exit codes (1/2/3) |
| Auto vs. manual workflow | Open-ended choice | Defaults to auto; `--manual` is opt-in |
| Background test process cleanup (manual mode) | Not mentioned | `trap` kills the test PID on exit |

## What still needs judgment (intentionally)

Deciding, per uncovered file, between *write a test*, *add `// coverage:ignore-file`*, or *acceptable gap* is a design call, not a mechanical one. The script surfaces those files in `coverage/summary.txt` and stderr so the reviewer operates on structured input.

## Testing

- [ ] `bash -n collect_coverage.sh` passes.
- [x] The script is idempotent: re-running on a project that already has `coverage` in `dev_dependencies` skips `pub add`.
- [ ] Exit codes: `0` success, `1` not a Dart project, `2` collection failed, `3` outputs missing/empty.
- [ ] Run this skill on pure dart project without coverage and with coverage
- [ ] Run this skill on flutter mono repo
- [x] Run this script on simple flutter project
```
 ../skills/skills/dart-collect-coverage/collect_coverage.sh
[collect_coverage] detected Flutter project
[collect_coverage] step 1/3: Flutter project — skipping 'coverage' dev dep (built into Flutter SDK)
[collect_coverage] step 2/3: running 'flutter test --coverage'
00:01 +1: All tests passed!
[collect_coverage] step 3/3: validating outputs
[collect_coverage] wrote coverage/lcov.info, coverage/summary.txt
[collect_coverage] files reported: 1, files with 0% coverage: 0
```

Happy to iterate on naming, on whether the script should live next to `SKILL.md` or under a shared `bin/`, or on adding an `--auto-ignore-generated` flag for `*.g.dart` / `*.freezed.dart` / `*.mocks.dart`.