### PR TITLE
Add --yes flag to skills add command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The `--agent universal` flag puts it in the standard `.agents/skills`
 folder that most agents use.
 
 ```bash
-npx skills add dart-lang/skills --skill '*' --agent universal
+npx skills add dart-lang/skills --skill '*' --agent universal --yes
 ```
 
 ## Updating Skills


### PR DESCRIPTION
This PR updates the README installation example for Dart AI skills by adding the --yes flag to the npx skills add command.

Changes Made

Updated command:

npx skills add dart-lang/skills --skill '*' --agent universal --yes
Reason for Change

Adding the --yes option allows the command to run without interactive confirmation prompts. This makes the setup process more streamlined and improves compatibility with automated environments such as CI pipelines, setup scripts, and containerized workflows.

Fixes
Fixes automated installation interruption caused by confirmation prompts.
Improves developer onboarding experience for Dart AI skills setup.
Pre-launch Checklist
 I read the Contributor Guide and followed the required contribution process.
 I reviewed the Tree Hygiene documentation.
 I followed the Flutter/Dart repository style guidelines.
 I signed the CLA.
 I included at least one issue or problem addressed by this PR.
 I updated relevant documentation.
 This is a documentation-only change and is test-exempt.
 All existing tests continue to pass.