### PR TITLE
Update dart_skills_lint dependency to e449787 and inherit target configuration

### DIFF
--- a/repo_tool/pubspec.yaml
+++ b/repo_tool/pubspec.yaml
@@ -16,4 +16,4 @@ dev_dependencies:
     git:
       url: https://github.com/flutter/skills.git
       path: tool/dart_skills_lint
-      ref: 76a8212ba25b3926311baab1f980ab995643c208
+      ref: e4497873950727ee781fa411c1a2f624b1ec50c6

--- a/repo_tool/test/lint_skills_test.dart
+++ b/repo_tool/test/lint_skills_test.dart
@@ -7,6 +7,8 @@ import 'package:dart_skills_lint/dart_skills_lint.dart';
 import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 
+const String _configFilePath = 'dart_skills_lint.yaml';
+
 void main() {
   test('Run skills linter', () async {
     // Enable logging to see detailed validation errors in test output.
@@ -16,13 +18,10 @@ void main() {
         .listen((record) => print(record.message));
 
     try {
-      final isValid = await validateSkills(
-        skillDirPaths: ['../skills'],
-        resolvedRules: {
-          'check-relative-paths': AnalysisSeverity.error,
-          'check-trailing-whitespace': AnalysisSeverity.error,
-        },
+      final Configuration config = await ConfigParser.loadConfig(
+        path: _configFilePath,
       );
+      final bool isValid = await validateSkills(config: config);
       expect(
         isValid,
         isTrue,


### PR DESCRIPTION
### Description
Updates the pinned `dart_skills_lint` dependency reference to commit `e4497873950727ee781fa411c1a2f624b1ec50c6` and refactors the validation test suite to load the centralized `dart_skills_lint.yaml` configuration dynamically. This ensures all target validation paths and rules are natively inherited from a single source of truth.
### Modifications
- **pubspec.yaml**: Rolled `dart_skills_lint` ref to `e4497873950727ee781fa411c1a2f624b1ec50c6`.
- **lint_skills_test.dart**: Added `_configFilePath`, dynamically loaded `Configuration` via `ConfigParser.loadConfig`, supplied `config` object directly to `validateSkills`, and removed redundant inline `skillDirPaths` and `resolvedRules`.
### Verification & Testing
- [x] Executed `dart format` cleanly.
- [x] Confirmed zero issues via `dart analyze --fatal-infos`.
- [x] Executed test suite natively via `dart test` with 100% passing status.