### PR TITLE
Update dart_skills_lint dependency to 3d375fe

### DIFF
--- a/repo_tool/pubspec.yaml
+++ b/repo_tool/pubspec.yaml
@@ -16,4 +16,4 @@ dev_dependencies:
     git:
       url: https://github.com/flutter/skills.git
       path: tool/dart_skills_lint
-      ref: e4497873950727ee781fa411c1a2f624b1ec50c6
+      ref: 3d375fed1b5f6bfe2881a601a4b6d91588594ff6


### PR DESCRIPTION
This updates to the version of dart_skills_lint that can take parameters and has breaking changes that will be removed  in the next release. - @reidbaker 

Agent Authored Description below
---
Bumps the pinned `dart_skills_lint` dependency ref in `repo_tool/pubspec.yaml` to the latest main commit (`3d375fed1b5f6bfe2881a601a4b6d91588594ff6`).

- **Dependency Update**: Pinned `dart_skills_lint` to `3d375fed1b5f6bfe2881a601a4b6d91588594ff6`.
- **Verification**: `dart analyze` and `dart test` passed cleanly.