### PR TITLE
fix: add metadata.last_modified to dart-write-documentation skill

### DIFF
--- a/skills/dart-write-documentation/SKILL.md
+++ b/skills/dart-write-documentation/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: dart-write-documentation
 description: "Rules and formatting guidelines for writing Dart /// API documentation and doc comments. Use when documenting Dart code, writing doc comments for any Dart declaration (libraries, classes, methods, variables, etc.), or when instructed to follow the Effective Dart documentation guidelines."
+metadata:
+  model: models/gemini-3.1-pro-preview
+  last_modified: Thu, 20 Aug 2026 12:53:22 GMT
 ---
 
 # Writing Dart API Documentation


### PR DESCRIPTION
Add the missing `metadata` block containing `model` and `last_modified` to the YAML frontmatter in `skills/dart-write-documentation/SKILL.md`. ### Context & Rationale
1. `dart-write-documentation` was introduced in PR dart-lang/skills#37 without the `metadata` frontmatter block that exists on other skills in this repo.
2. Skills are synced to flutter/agent-plugins via automated sync (PR #224).
3. Downstream CI in flutter/agent-plugins runs `LastModifiedRule`, which strictly enforces that all skills under `skills/` contain `metadata.last_modified`.
4. Without this field, any downstream PR touching skills (such as #230) fails CI.
5. Downstream policy workflow `block-dart-skills-prs.yaml` requires all `skills/dart-*` fixes to originate upstream in dart-lang/skills (#232). Refs:
- Upstream PR: https://github.com/dart-lang/skills/pull/37
- Downstream Sync PR: https://github.com/flutter/agent-plugins/pull/224
- Downstream Blocked PR: https://github.com/flutter/agent-plugins/pull/230
- Downstream Policy PR: https://github.com/flutter/agent-plugins/pull/232
