### PR TITLE
ci: validate dart formatting and analysis across skills directory

### DIFF
--- a/.github/workflows/dart_skills_validation.yaml
+++ b/.github/workflows/dart_skills_validation.yaml
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Setup Dart
-      uses: dart-lang/setup-dart@v1
+      uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1.7.1
 
     - name: Install dependencies
       run: dart pub get

--- a/.github/workflows/dart_skills_validation.yaml
+++ b/.github/workflows/dart_skills_validation.yaml
@@ -33,11 +33,13 @@ jobs:
     - name: Install dependencies
       run: dart pub get
 
-    - name: Verify formatting
+    - name: Verify formatting across repository
+      working-directory: .
       run: dart format --output=none --set-exit-if-changed .
 
-    - name: Analyze project source
-      run: dart analyze --fatal-infos
+    - name: Analyze project source and skills
+      working-directory: .
+      run: dart analyze --fatal-infos --packages=repo_tool/.dart_tool/package_config.json repo_tool skills
 
     - name: Run tests
       run: dart test

--- a/repo_tool/pubspec.yaml
+++ b/repo_tool/pubspec.yaml
@@ -9,7 +9,11 @@ dependencies:
   path: ^1.9.0
 
 dev_dependencies:
+  args: ^2.5.0
+  cli_util: ^0.6.0
+  io: ^1.0.4
   lints: ^6.0.0
   logging: ^1.2.0
   skills_lint: ^0.5.1
+  stack_trace: ^1.12.0
   test: ^1.25.6


### PR DESCRIPTION
- Extends `dart_skills_validation.yaml` and `repo_tool/pubspec.yaml` dev_dependencies so CI verifies formatting and runs `dart analyze --fatal-infos` across both `repo_tool` and `skills` directories. `repo_tool` acts as the shared package configuration for analyzing code snippets and examples across `skills/`.
- Pins `actions/checkout` and `dart-lang/setup-dart` to full commit SHAs to satisfy the `zizmor/unpinned-uses` security check:
  - Upgraded `actions/checkout` from `v3` to `v4.2.2` (`11bd71901bbe5b1630ceea73d27597364c9af683`) to run on Node 20 runtime and prevent deprecated Node 16 runner warnings.
  - Pinned `dart-lang/setup-dart` to `v1.7.1` (`e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c`).
- Commit SHA Verification Attestation:
  - `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683` matches upstream release tag `refs/tags/v4.2.2`
  - `dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c` matches upstream release tag `refs/tags/v1.7.1`